### PR TITLE
changes how zstd is found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build-*
+build*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,25 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(MSz LANGUAGES CXX CUDA C)
+project(MSz LANGUAGES CXX C)
 
 include(GNUInstallDirs)
-find_package(PkgConfig REQUIRED)
-pkg_search_module(ZSTD IMPORTED_TARGET libzstd)
+# find_package(PkgConfig REQUIRED)
+# pkg_search_module(ZSTD IMPORTED_TARGET libzstd)
+
+find_package (zstd REQUIRED)
 
 option(ENABLE_CUDA "Enable CUDA acceleration" OFF)
 
 if (ENABLE_CUDA)
-    find_package(CUDAToolkit)
-    if (CUDAToolkit_FOUND)
-        set(USE_CUDA TRUE)
-        message(STATUS "CUDA support enabled in MSz.")
-    else()
-        message(WARNING "CUDA not found, disabling CUDA acceleration.")
-        set(USE_CUDA FALSE)
-    endif() # 结束 CUDAToolkit_FOUND 检查
+    enable_language (CUDA)
+    # find_package(CUDAToolkit)
+    # if (CUDAToolkit_FOUND)
+    #     set(USE_CUDA TRUE)
+    #     message(STATUS "CUDA support enabled in MSz.")
+    # else()
+    #     message(WARNING "CUDA not found, disabling CUDA acceleration.")
+    #     set(USE_CUDA FALSE)
+    # endif() # 结束 CUDAToolkit_FOUND 检查
 endif() # 结束 ENABLE_CUDA 检查
 
 option(ENABLE_OPENMP "Enable OpenMP acceleration" OFF)
@@ -45,7 +48,7 @@ if (USE_OPENMP)
 endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
-add_library(MSz STATIC ${SRC_FILES})
+add_library(MSz SHARED ${SRC_FILES})
 
 target_compile_features(MSz PRIVATE cxx_std_17)
 
@@ -67,7 +70,8 @@ if (USE_OPENMP)
     target_compile_definitions(MSz PRIVATE OPENMP_ENABLED)
 endif()
 
-target_link_libraries(MSz PRIVATE PkgConfig::ZSTD)
+# target_link_libraries(MSz PRIVATE PkgConfig::ZSTD)
+target_link_libraries(MSz PRIVATE zstd::libzstd)
 
 install(TARGETS MSz
         EXPORT MSzTargets

--- a/src/api/MSz.cpp
+++ b/src/api/MSz.cpp
@@ -4,7 +4,7 @@
 #include <sstream>
 #include <vector>
 #include <cstdlib>
-#include <stdatomic.h>
+// #include <stdatomic.h>
 #include <unordered_map>
 #include <random>
 #include <atomic>

--- a/src/internal/MSz_Global/MSz_globals.cpp
+++ b/src/internal/MSz_Global/MSz_globals.cpp
@@ -9,7 +9,7 @@
 #include <vector>
 #include <cstdlib>
 #include <fstream>
-#include <stdatomic.h>
+// #include <stdatomic.h>
 #include <cmath>
 #include <parallel/algorithm>  
 #include <unordered_map>


### PR DESCRIPTION
I've updated how ZSTD is found.  One should point to the cmake configuration in ZSTD's installation path, e.g., 

`cmake .. -Dzstd_DIR=$HOME/local/zstd-1.5.6/lib/cmake/zstd`

I also made misc changes to not include CUDA as a language when ENABLE_CUDA is off.